### PR TITLE
fix: reset `section > section` styles on front page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -179,6 +179,12 @@ section {
   padding-bottom:50px;
 }
 
+section > section {
+  width:auto;
+  float:none;
+  padding-bottom:0;
+}
+
 small {
   font-size:11px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -228,6 +228,13 @@ footer {
     margin:0 0 20px;
   }
 
+  section > section {
+    border:none;
+    border-width:0;
+    padding:0;
+    margin:0;
+  }
+
   header a small {
     display:inline;
   }


### PR DESCRIPTION
## What does this PR do?
Fix

### Description

At fpb theme:
![image](https://user-images.githubusercontent.com/3125580/177856901-e829aa61-7115-425a-8644-901b40e82a7a.png)

At fpb-search theme:
![image](https://user-images.githubusercontent.com/3125580/177857553-105808e3-8663-4874-97f5-966880d5ea22.png)

This fix resets `section > section` selector for all media queries and then, reverts the double gap at the front page. 

Search result page styles continues OK due to selector is `section > div`