### PR TITLE
[BUGFIX-37] Relative urls with a harcoded contextPath

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,6 +56,7 @@ function jsonToArray(json) {
 }
 
 function App() {
+  const appContextPath = "/free-programming-books-search/";
   // keeps the state of the json
   const [data, setData] = useState(undefined); 
   // put all books into one array. uses more memory, but search is faster and less complex
@@ -89,13 +90,13 @@ function App() {
     async function fetchData() {
       try {
         setQueries(queryString.parse(document.location.search));
-    if (queries.lang) {
-      if (queries.lang === "langs" || queries.lang === "subjects") {
-        changeParameter("lang.code", "en");
-      } else {
-        changeParameter("lang.code", queries.lang);
-      }
-    }
+        if (queries.lang) {
+          if (queries.lang === "langs" || queries.lang === "subjects") {
+            changeParameter("lang.code", "en");
+          } else {
+            changeParameter("lang.code", queries.lang);
+          }
+        }
         // setLoading(true);
         let result = await axios.get(
           "https://raw.githubusercontent.com/EbookFoundation/free-programming-books-search/main/fpb.json"
@@ -201,7 +202,7 @@ function App() {
       //         lang: entry.item.lang,
       //         section: entry.item.section,
       //         title: `List of all ${section} books in ${entry.item.lang.name}`,
-      //         url: `/free-programming-books-search?sect=books&lang=${langCode}&file=free-programming-books-${langCode}#${section}`,
+      //         url: `${appContextPath}?sect=books&lang=${langCode}&file=free-programming-books-${langCode}#${section}`,
       //         samePage: true,
       //       },
       //     };
@@ -253,7 +254,7 @@ function App() {
       </ThemeContext.Consumer>
       <header className="header">
         <h1>
-          <a href="/free-programming-books-search/">free-programming-books</a>
+          <a href={`${appContextPath}`}>free-programming-books</a>
         </h1>
 
         <p>

--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,7 @@ function jsonToArray(json) {
 }
 
 function App() {
-  const appContextPath = "/free-programming-books-search/";
+  const appContextPath = process.env.PUBLIC_URL + "/";
   // keeps the state of the json
   const [data, setData] = useState(undefined); 
   // put all books into one array. uses more memory, but search is faster and less complex

--- a/src/components/ParsedLink.js
+++ b/src/components/ParsedLink.js
@@ -30,7 +30,7 @@ function ParsedLink({ children, sect, href, id }) {
   }, [href]);
 
   if (folder && file) {
-    return <a id={id} href={`${appContextPath}?&sect=${folder}&file=${file}`}>{children}</a>;
+    return <a id={id} href={`${appContextPath}?sect=${folder}&file=${file}`}>{children}</a>;
   } else if (file) {
     return <a id={id} href={`${appContextPath}?file=${file}`}>{children}</a>;
   } else { // Go to the homepage when there's a bad relative URL

--- a/src/components/ParsedLink.js
+++ b/src/components/ParsedLink.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 
 function ParsedLink({ children, sect, href, id }) {
-  const appContextPath = "/free-programming-books-search/";
+  const appContextPath = process.env.PUBLIC_URL + "/";
   const [folder, setFolder] = useState(null);
   const [file, setFile] = useState(null);
 

--- a/src/components/ParsedLink.js
+++ b/src/components/ParsedLink.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 
 function ParsedLink({ children, sect, href, id }) {
+  const appContextPath = "/free-programming-books-search/";
   const [folder, setFolder] = useState(null);
   const [file, setFile] = useState(null);
 
@@ -29,11 +30,11 @@ function ParsedLink({ children, sect, href, id }) {
   }, [href]);
 
   if (folder && file) {
-    return <a id={id} href={`/free-programming-books-search/?&sect=${folder}&file=${file}`}>{children}</a>;
+    return <a id={id} href={`${appContextPath}?&sect=${folder}&file=${file}`}>{children}</a>;
   } else if (file) {
-    return <a id={id} href={`/free-programming-books-search/?file=${file}`}>{children}</a>;
+    return <a id={id} href={`${appContextPath}?file=${file}`}>{children}</a>;
   } else { // Go to the homepage when there's a bad relative URL
-    return <a id={id} href={`/free-programming-books-search/`}>{children}</a>
+    return <a id={id} href={`${appContextPath}`}>{children}</a>
   }
 }
 


### PR DESCRIPTION
## What does this PR do?
Add feature(s) | Fix

### Description

Allow install app in other context path different to `/free-programming-books-search` to increase flexibility

### Context

Resolves #37 

Test deploy: https://davorpa.github.io/free-programming-books-search/ Check:
- H1 link goes to homepage `/free-programming-books-search/`
- Any link in homepage goes to it related file (docs or listings)
- No extra ampersand in them before `sect` parameter